### PR TITLE
Set CMake minimum version to 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.6)
 project(metamod CXX)
 
 if (WIN32)

--- a/metamod/CMakeLists.txt
+++ b/metamod/CMakeLists.txt
@@ -21,7 +21,7 @@
 #
 #----------------------------------------
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.6)
 project(metamod CXX)
 
 option(DEBUG "Build with debug information." OFF)


### PR DESCRIPTION
## Purpose
This fixes the `Compatibility with CMake < 3.5 has been removed from CMake.` error when compiling on Linux.

## Approach
Set the CMake minimum version to 3.6