### PR TITLE
metamod: remove -s strip flag to preserve linker markers

### DIFF
--- a/metamod/CMakeLists.txt
+++ b/metamod/CMakeLists.txt
@@ -46,7 +46,6 @@ if (DEBUG)
 	set(COMPILE_FLAGS "${COMPILE_FLAGS} -g3 -O0 -ggdb")
 else()
 	set(COMPILE_FLAGS "${COMPILE_FLAGS} -g0 -O3 -fno-stack-protector")
-	set(LINK_FLAGS "${LINK_FLAGS} -s")
 endif()
 
 # Check Intel C++ compiler


### PR DESCRIPTION
## Summary

The `-s` flag in `LINK_FLAGS` inside the non-debug branch causes `strip` to run on the output shared library, which removes all symbols from the binary — including sentinel symbols used by packaging systems to verify that `LDFLAGS` were respected.

For example, Gentoo injects `--defsym=__gentoo_check_ldflags__=0` into `LDFLAGS` and then checks that the resulting binary still contains `__gentoo_check_ldflags__` after linking. The `-s` strip pass removes it, causing a QA failure:

```
* QA Notice: Files built without respecting LDFLAGS have been detected
```

Stripping should be left to the build system or packager (e.g. via `INSTALL_STRIP_FLAG` or `CMAKE_INSTALL_DO_STRIP`), not hardcoded into link flags.

## Change

Remove `set(LINK_FLAGS "${LINK_FLAGS} -s")` from the non-debug branch in `metamod/CMakeLists.txt`.